### PR TITLE
fix(deps): keep js-yaml on 4.x so the release job can load it

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ overrides:
   '@hono/node-server@<2.0.5': '>=2.1.1'
   hono@<4.12.27: '>=4.13.2'
   ip-address@<=10.1.0: '>=10.5.0'
-  js-yaml@>=3.0.0 <3.15.1: ^5.3.0
+  js-yaml@>=3.0.0 <3.15.1: ^3.15.1
   lodash-es@<=4.17.23: '>=4.18.0'
   lodash-es@>=4.0.0 <=4.17.23: '>=4.18.0'
   lodash@<=4.17.23: '>=4.18.0'
@@ -617,7 +617,7 @@ overrides:
   yaml@>=2.0.0 <2.8.3: '>=2.9.0'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.2'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
-  js-yaml@>=4.0.0 <4.3.0: ^5.3.0
+  js-yaml@>=4.0.0 <4.3.0: ^4.3.1
 
 packageExtensionsChecksum: sha256-Ohls6Z6vcdyi3RZbeQP4q6j0GZbWIp1q8TsKkyYnjVw=
 
@@ -6129,6 +6129,9 @@ packages:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -9178,12 +9181,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@5.3.0:
-    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.2.0:
@@ -11471,6 +11474,9 @@ packages:
   split@0.2.10:
     resolution: {integrity: sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   srvx@0.12.5:
     resolution: {integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==}
     engines: {node: '>=20.16.0'}
@@ -12427,7 +12433,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=8.2.0'
+      vite: '>=7.3.2'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -13217,7 +13223,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
 
   '@arethetypeswrong/cli@0.18.5':
     dependencies:
@@ -14454,7 +14460,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -14572,7 +14578,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 5.3.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -15896,7 +15902,7 @@ snapshots:
   '@semrel-extra/topo@1.14.1':
     dependencies:
       fast-glob: 3.3.3
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       toposource: 1.2.0
 
   '@simple-libs/child-process-utils@2.0.0':
@@ -17861,6 +17867,10 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   argue-cli@3.1.0: {}
@@ -18560,13 +18570,13 @@ snapshots:
   cosmiconfig@10.0.0:
     dependencies:
       env-paths: 2.2.1
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
 
   cosmiconfig@9.0.2(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -21835,11 +21845,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@3.15.1:
     dependencies:
-      argparse: 2.0.1
+      argparse: 1.0.10
+      esprima: 4.0.1
 
-  js-yaml@5.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -24274,7 +24285,7 @@ snapshots:
   rc-config-loader@4.1.4(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -24283,7 +24294,7 @@ snapshots:
   rc-config-loader@4.1.4(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      js-yaml: 5.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -25192,6 +25203,8 @@ snapshots:
   split@0.2.10:
     dependencies:
       through: 2.3.8
+
+  sprintf-js@1.0.3: {}
 
   srvx@0.12.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -272,8 +272,9 @@ overrides:
     # GHSA-xgm2-5f3f-mvvc
     hono@<4.12.27: ">=4.13.2"
     ip-address@<=10.1.0: ">=10.5.0"
-    # GHSA-5p4m-2wfm-xmqj (Quadratuc CPU in !!omap) — jest's load-nyc-config pulls 3.x
-    js-yaml@>=3.0.0 <3.15.1: "^5.3.0"
+    # GHSA-5p4m-2wfm-xmqj (Quadratuc CPU in !!omap) — jest's load-nyc-config pulls 3.x.
+    # Do not raise to v5; see the js-yaml@>=4.0.0 note below.
+    js-yaml@>=3.0.0 <3.15.1: "^3.15.1"
     lodash-es@<=4.17.23: ">=4.18.0"
     lodash-es@>=4.0.0 <=4.17.23: ">=4.18.0"
     lodash@<=4.17.23: ">=4.18.0"
@@ -300,7 +301,7 @@ overrides:
     form-data@>=4.0.0 <4.0.6: ">=4.0.6"
     # Stay on 4.x: js-yaml 5.x is ESM-only with no default export and breaks
     # multi-semantic-release's `import ... from "js-yaml"`. ^4.3.0 still patches GHSA-52cp-r559-cp3m.
-    js-yaml@>=4.0.0 <4.3.0: "^5.3.0"
+    js-yaml@>=4.0.0 <4.3.0: "^4.3.1"
 
 shellEmulator: true
 


### PR DESCRIPTION
The release job on `main` dies before publishing anything:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

## Cause

`@anolilab/multi-semantic-release` does `import yaml from "js-yaml"` in its bundled topo module. **js-yaml 5 dropped the default export** from its ESM build, so the import throws at load time.

Verified directly rather than inferred:

```
$ node --input-type=module -e "import y from '…/js-yaml@4.3.1/…/dist/js-yaml.mjs'; console.log(typeof y)"
object

$ same against 5.3.0
SyntaxError: … does not provide an export named 'default'
```

`pnpm exec multi-semantic-release --help` exits 0 on this branch; on `main` it is the command that fails.

## How it got in

#1117 raised both `js-yaml` overrides to `^5.3.0`. The `js-yaml@>=4.0.0 <4.3.0` entry has this comment sitting immediately above it:

```yaml
# Stay on 4.x: js-yaml 5.x is ESM-only with no default export and breaks
# multi-semantic-release's `import ... from "js-yaml"`. ^4.3.0 still patches GHSA-52cp-r559-cp3m.
js-yaml@>=4.0.0 <4.3.0: "^4.3.1"
```

I merged Renovate's bump straight past it. The failure mode was already documented in the file, one line above the change.

## Fix

Restore both ranges to their previous values, and add the same constraint to the 3.x entry so the next update does not silently repeat it:

| Range | Was (#1117) | Now |
| --- | --- | --- |
| `js-yaml@>=3.0.0 <3.15.1` | `^5.3.0` | `^3.15.1` |
| `js-yaml@>=4.0.0 <4.3.0` | `^5.3.0` | `^4.3.1` |

Both still patch the advisories the overrides exist for — `pnpm audit --audit-level=moderate` reports no known vulnerabilities.

## Verification

- `pnpm exec multi-semantic-release --help` — exit 0 (this is what fails on `main`)
- `pnpm install --frozen-lockfile` — exit 0
- audit clean, build 8/8, lint 6/6, tests 4/4 projects

## Follow-up worth considering

This is the second ESM-only major to slip through a dependency update today; the nanoid one was caught before merging only because it was checked by hand. A Renovate rule that holds majors for packages consumed via a default import, or simply treating an adjacent "stay on Nx" comment as blocking, would catch the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FP75FgnREe4L45kZtsa9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security overrides for `js-yaml` dependencies.
  * Preserved compatibility for applications using both 3.x and 4.x versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->